### PR TITLE
Update example.php

### DIFF
--- a/example.php
+++ b/example.php
@@ -52,7 +52,7 @@
 
 // TODO
 // Integrer les langues (champs/value) (http://www.prestashop.com/forums/index.php?/topic/189016-questions-sur-la-creation-de-modules-mvc/page__view__findpost__p__936271)
-// Integrer un fichier à télécharger (http://www.prestashop.com/forums/index.php?/topic/189016-questions-sur-la-creation-de-modules-mvc/page__view__findpost__p__939093)
+// Integrer un fichier ï¿½ tï¿½lï¿½charger (http://www.prestashop.com/forums/index.php?/topic/189016-questions-sur-la-creation-de-modules-mvc/page__view__findpost__p__939093)
 // Integrer des commandes sur addRowAction
 
 // Security
@@ -160,6 +160,8 @@ class Example extends Module
 		// Uninstall Tabs
 		$tab = new Tab((int)Tab::getIdFromClassName('AdminExample'));
 		$tab->delete();
+		$tabMain = new Tab((int)Tab::getIdFromClassName('AdminMainExample'));
+		$tabMain->delete();
 		
 		// Uninstall Module
 		if (!parent::uninstall())


### PR DESCRIPTION
suppression de Tab adminMainExample. Même si elle n'est pas affichée ( car vide) elle est présente en BDD. Cela créera des doublons dans la table à force d'installer / deinstaller
